### PR TITLE
ci: stop stacking Claude reviews and bound job runtimes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,12 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+# A review is only useful for the PR's current head. Without this, every push
+# to a busy PR started another review while the previous one was still running.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # Optional: Filter by PR author
@@ -19,6 +25,7 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
     
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,10 @@ on:
   pull_request_review:
     types: [submitted]
 
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   claude:
     if: |
@@ -18,6 +22,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
Part of an org-wide GitHub Actions audit (cost, workflow defects, and fallout from the Code Security / Secret Protection teardown). Reference implementation: `zerolve-io/coursecards` PR #709.

This repo is **public**, so standard-runner minutes are free, and it only has the two Claude workflows — so this is a small PR.

## Stacked reviews

`claude-code-review.yml` triggers on `pull_request: types: [opened, synchronize]` with no `concurrency` group. Every push to a busy PR started another full review while the previous one was still running — burning runner time and posting reviews of superseded commits. Added a per-PR group with `cancel-in-progress: true`; a review is only useful for the PR's current head.

`claude.yml` gets a group too, but **without** cancellation: an `@claude` mention is an explicit request from a human, and discarding one because a second arrived would be the wrong behaviour. Grouping alone is enough to keep them serialised per issue/PR.

## Unbounded runtimes

Neither job declared `timeout-minutes`, so a hung action held a runner for GitHub's **six-hour** default. Added 30 minutes to both.

## Verified statically

- Both workflows: YAML parses, no dangling `needs:`, no `run:` blocks to shell-check
- No Actions minutes spent testing this

## Not changed — needs a human decision

1. **`anthropics/claude-code-action@beta`** in both workflows is an unpinned, moving tag, and `@beta` has been superseded by `@v1`. Whatever lands on that tag executes here with `CLAUDE_CODE_OAUTH_TOKEN` in scope.
2. **`direct_prompt:`** (used in `claude-code-review.yml`) was renamed in v1. So the upgrade is not a drop-in — the input needs renaming at the same time. I left both alone rather than risk breaking your review bot inside a CI-hygiene PR, but they should move together in a follow-up.
3. **`permissions:` are read-only** (`contents: read`, `pull-requests: read`, `issues: read`) in both workflows. If you expect Claude to post review comments or push commits, those need `write` — worth confirming the bot is actually able to do what you want today.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoqdmMgJUqF6dNXd2m46Kp)_